### PR TITLE
Use variables from _config.yml instead of hard-coded values

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,3 +8,7 @@ github:
   owner_name: RTE France
   owner_url: https://www.rte-france.com
 
+hades2:
+  release: 6.4.0
+  version: 6.4.0.1.1
+  integration_version: 2.8.0

--- a/hades2/configuration/ADNLimitReductionsParameters.md
+++ b/hades2/configuration/ADNLimitReductionsParameters.md
@@ -4,9 +4,9 @@ layout: default
 ---
 
 # ADNLimitReductionsParameters
-The `com.rte_france.powsybl.iidm.export.adn.ADNLimitReductionsParameters` class is used to model limit reductions for a
-given voltage range (inclusive). It contains a coefficient for permanent limits and a list of coefficients for temporary
-limits.
+The [ADNLimitReductionsParameters](https://javadoc.io/doc/com.rte-france.powsybl/powsybl-rte-core/latest/com/rte_france/powsybl/iidm/export/adn/ADNLimitReductionsParameters.html)
+class is used to model limit reductions for a given voltage range (inclusive). It contains a coefficient for permanent
+limits and a list of coefficients for temporary limits.
 
 ## Optional properties
 

--- a/hades2/configuration/ADNLoadFlowParameters.md
+++ b/hades2/configuration/ADNLoadFlowParameters.md
@@ -3,10 +3,12 @@ title: ADNLoadFlowParameters
 layout: default
 ---
 
-The `com.rte_france.powsybl.iidm.export.adn.ADNLoadFlowParameters` is an extension of the
-`com.powsybl.loadflow.LoadFlowParameters` class that provides specific configuration for the load flow
-mode of Hades. Read this [documentation](http://powsybl.github.io/docs/configuration/parameters/LoadFlowParameters.html)
-page to learn more about load flow generic parameters.
+The [ADNLoadFlowParameters](https://javadoc.io/doc/com.rte-france.powsybl/powsybl-rte-core/latest/com/rte_france/powsybl/iidm/export/adn/ADNLoadFlowParameters.html)
+is an extension of the [LoadFlowParameters](https://javadoc.io/doc/com.powsybl/powsybl-core/latest/com/powsybl/loadflow/LoadFlowParameters.html)
+class that provides specific configuration for the load flow mode of Hades.
+
+Read this [documentation](http://powsybl.github.io/docs/configuration/parameters/LoadFlowParameters.html) page to learn
+more about load flow generic parameters.
 
 # Optional properties
 

--- a/hades2/configuration/ADNSecurityAnalysisParameters.md
+++ b/hades2/configuration/ADNSecurityAnalysisParameters.md
@@ -3,11 +3,12 @@ title: ADNSecurityAnalysisParameters
 layout: default
 ---
 
-The `com.rte_france.powsybl.iidm.export.adn.ADNSecurityAnalysisParameters` is an extension of the
-`com.powsybl.security.SecurityAnalysisParameters` class that provides specific configuration for the security analysis
-mode of Hades. Read this [documentation](http://powsybl.github.io/docs/configuration/parameters/SecurityAnalysisParameters.html)
-page to learn more about security analysis generic parameters. Read this [documentation](ADNLoadFlowParameters.md) page
-to learn more about the Hades load-flow configuration.
+The [ADNSecurityAnalysisParameters](https://javadoc.io/doc/com.rte-france.powsybl/powsybl-rte-core/latest/com/rte_france/powsybl/iidm/export/adn/ADNSecurityAnalysisParameters.html)
+is an extension of the [SecurityAnalysisParameters](https://javadoc.io/doc/com.powsybl/powsybl-core/latest/com/powsybl/security/SecurityAnalysisParameters.html)
+class that provides specific configuration for the security analysis mode of Hades.
+Read this [documentation](http://powsybl.github.io/docs/configuration/parameters/SecurityAnalysisParameters.html) page to
+learn more about security analysis generic parameters. Read this [documentation](ADNLoadFlowParameters.md) page to learn
+more about the Hades load-flow configuration.
 
 # Optional properties
 

--- a/hades2/configuration/hades2.md
+++ b/hades2/configuration/hades2.md
@@ -28,7 +28,7 @@ this property is `false` which means XML files are parsed with DOM by default.
 ## YAML
 ```yaml
 hades2:
-    homeDir: /home/user/hades2-V5.5.1.2
+    homeDir: /home/user/hades2-V{{ site.hades2.version }}
     timeout: 60
     debug: false
     useSAX: true
@@ -37,7 +37,7 @@ hades2:
 ## XML
 ```xml
 <hades2>
-    <homeDir>/home/user/hades2-V5.5.1.2</homeDir>
+    <homeDir>/home/user/hades2-V{{ site.hades2.version }}</homeDir>
     <timeout>60</timeout>
     <debug>false</debug>
     <useSAX>false</useSAX>

--- a/hades2/features/action-simulator.md
+++ b/hades2/features/action-simulator.md
@@ -20,7 +20,7 @@ load-flow-action-simulator:
     max-iterations: 10
     
 hades2:
-    homeDir: /home/user/hades2-V5.5.1.2
+    homeDir: /home/user/hades2-V{{ site.hades2.version }}
     debug: false
     useSax: true
 ```
@@ -36,7 +36,7 @@ hades2:
     </load-flow-action-simulator>
     
     <hades2>
-        <homeDir>/home/user/hades2-V5.5.1.2</homeDir>
+        <homeDir>/home/user/hades2-V{{ site.hades2.version }}</homeDir>
         <debug>false</debug>
         <useSax>true</useSax>
     </hades2>

--- a/hades2/features/loadflow.md
+++ b/hades2/features/loadflow.md
@@ -5,6 +5,7 @@ layout: default
 
 # Configuration
 To use Hades for load-flow computations, set the `default` property of the [load-flow](http://powsybl.github.io/docs/configuration/modules/load-flow.html) module to `Hades2`.
+
 **Note**: In previous Powsybl releases (before 3.0.0), this was configured in the `load-flow-factory` property with the value `com.rte_france.powsybl.hades2.Hades2Factory`.
 
 To setup Hades, configure the [hades2](../configuration/hades2.md) module.
@@ -15,7 +16,7 @@ load-flow:
     default: Hades2
     
 hades2:
-    homeDir: /home/user/hades2-V5.5.1.2
+    homeDir: /home/user/hades2-V{{ site.hades2.version }}
     debug: false
     useSax: true
 ```
@@ -28,7 +29,7 @@ hades2:
     </load-flow>
     
     <hades2>
-        <homeDir>/home/user/hades2-V5.5.1.2</homeDir>
+        <homeDir>/home/user/hades2-V{{ site.hades2.version }}</homeDir>
         <debug>false</debug>
         <useSax>true</useSax>
     </hades2>

--- a/hades2/features/security-analysis.md
+++ b/hades2/features/security-analysis.md
@@ -6,7 +6,7 @@ layout: default
 # Configuration
 To use Hades for security analysis computations, set the `SecurityAnalysisFactory` property of the
 [componentDefaultConfig](http://powsybl.github.io/docs/configuration/modules/componentDefaultConfig.html) module to
-`com.rte_france.powsybl.hades2.Hades2SecurityAnalysisFactory`
+[Hades2SecurityAnalysisFactory](https://javadoc.io/doc/com.rte-france.powsybl/powsybl-rte-core/latest/com/rte_france/powsybl/hades2/Hades2SecurityAnalysisFactory.html).
 
 To setup Hades, configure the [hades2](../configuration/hades2.md) module.
 
@@ -16,7 +16,7 @@ componentDefaultConfig:
     SecurityAnalysisFactory: com.rte_france.powsybl.hades2.Hades2SecurityAnalysisFactory
     
 hades2:
-    homeDir: /home/user/hades2-V5.5.1.2
+    homeDir: /home/user/hades2-V{{ site.hades2.version }}
     debug: false
     useSax: true
 ```
@@ -29,7 +29,7 @@ hades2:
     </componentDefaultConfig>
     
     <hades2>
-        <homeDir>/home/user/hades2-V5.5.1.2</homeDir>
+        <homeDir>/home/user/hades2-V{{ site.hades2.version }}</homeDir>
         <debug>false</debug>
         <useSax>true</useSax>
     </hades2>

--- a/hades2/index.md
+++ b/hades2/index.md
@@ -7,7 +7,7 @@ Hades is a free software distributed by [RTE France](https://www.rte-france.com)
 
 # License
 
-RTE provides closed-source jars to integrate Hades to an application based on [powsybl](http://www.powsybl.com). Hades2 is distributed in the form of closed source because it is a legacy software that is not suitable for open source collaboration. Please read the complete software [license](license.md) agreement before going further.
+RTE provides closed-source jars to integrate Hades to an application based on [powsybl](http://www.powsybl.org). Hades2 is distributed in the form of closed source because it is a legacy software that is not suitable for open source collaboration. Please read the complete software [license](license.md) agreement before going further.
 
 # Installation guide
 Hades is compatible with Linux (64 bits) and with Windows (64 bits) environments.
@@ -25,16 +25,19 @@ To download and use Hades2, please agree to the license agreement by checking th
 <label for="hades2-toggle">I agree to the hades2 license agreement</label>
 <input id="hades2-toggle" type="checkbox" name="hades2-toggle">
 <div id="hades2-link">
-<p> Linux distribution (64 bits): <a href="https://github.com/rte-france/hades2-distribution/releases/download/V6.4.0/hades2-V6.4.0.1.1-linux.tar.gz">hades2-V6.4.0.1.1-linux.tar.gz</a></p>
-<p> Windows distribution (64 bits): <a href="https://github.com/rte-france/hades2-distribution/releases/download/V6.4.0/hades2-V6.4.0.1.1-windows.zip">hades2-V6.4.0.1.1-windows.zip</a></p>
+<ul>
+<li>Linux distribution (64 bits): <a href="https://github.com/rte-france/hades2-distribution/releases/download/V{{ site.hades2.release }}/hades2-V{{ site.hades2.version }}-linux.tar.gz">hades2-V{{ site.hades2.version }}-linux.tar.gz</a></li>
+<li>Windows distribution (64 bits): <a href="https://github.com/rte-france/hades2-distribution/releases/download/V{{ site.hades2.release }}/hades2-V{{ site.hades2.version }}-windows.zip">hades2-V{{ site.hades2.version }}-windows.zip</a></li>
+</ul>
+<p>Previous releases can be found on <a href="https://github.com/rte-france/hades2-distribution/releases">Hades2 Github page</a>.</p>
 </div>
 </div>
 
 ## Install
 To install Hades, simply extract the content of the archive.
 ```shell
-$> tar xf hades2-V6.2.0.1-linux.tar.gz
-$> cd hades2-V6.2.0.1
+$> tar xf hades2-V{{ site.hades2.version }}-linux.tar.gz
+$> cd hades2-V{{ site.hades2.version }}
 $> ./hades2
 init iodico
 RTE load flow tool - RTE HADES trial and academic license expiring the 31/10/2019
@@ -64,7 +67,13 @@ dependencies to the `pom.xml` file:
 <dependency>
     <groupId>com.rte-france.powsybl</groupId>
     <artifactId>powsybl-hades2-integration</artifactId>
-    <version>2.6.0</version>
+    <version>{{ site.hades2.integration_version }}</version>
+    <scope>runtime</scope>
+</dependency>
+<dependency>
+    <groupId>org.slf4j</groupId>
+    <artifactId>log4j-over-slf4j</artifactId>
+    <version>1.7.21</version>
     <scope>runtime</scope>
 </dependency>
 ```
@@ -73,9 +82,12 @@ Read how to create a powsybl bundle based on [itools](http://powsybl.github.io/d
 or on the [Grid Study Environment](http://powsybl.github.io/docs/installation/javafx-packager.html), a JavaFX desktop
 application.
 
-The `itools-packager` plugin of powsybl-core will copy all the maven dependencies to the share/java folder of the distribution. To enable a feature, you have to add a runtime dependency to the `pom.xml` file. 
+The `itools-packager` plugin of powsybl-core will copy all the maven dependencies to the share/java folder of the distribution.
+To enable a feature, you have to add a runtime dependency to the `pom.xml` file. 
 
-If you do not want to modify the `pom.xml` file, you have to download the dependencies for Hades2 integration in the `share/java` folder of the itools distribution. The dependencies are available on Maven Central following that [link](https://mvnrepository.com/artifact/com.rte-france.powsybl). The following jar files have to be downloaded:
+If you do not want to modify the `pom.xml` file, you have to download the dependencies for Hades2 integration in the `share/java`
+folder of the itools distribution. The dependencies are available on Maven Central following that [link](https://mvnrepository.com/artifact/com.rte-france.powsybl).
+The following jar files have to be downloaded:
 ```
 powsybl-adn-api
 powsybl-hades2-integration
@@ -103,6 +115,8 @@ actions simulations.
 
 # What's next ?
 
-Our goal is to have also open source computation modules integrated to PowSyBl (load flows, time domain simulators, optimizers, etc.). This is however work in progress and we would welcome contributions in that field.
+Our goal is to have also open source computation modules integrated to PowSyBl (load flows, time domain simulators, optimizers, etc.).
+This is however work in progress and we would welcome contributions in that field.
 
-Please also note that a simple DC load-flow is currently being developed mainly for demo purposes. The code is in the repository [powsybl-incubator](https://github.com/powsybl/powsybl-incubator).
+Please also note that a simple DC load-flow is currently being developed mainly for demo purposes. The code is in the repository
+[powsybl-open-loadflow](https://github.com/powsybl/powsybl-open-loadflow).


### PR DESCRIPTION
- Define variables to define the version of Hades2 binary and integration module
- Replace fully qualified class name by short names and links to the javadoc