### PR TITLE
Fix project logo size

### DIFF
--- a/_sass/minimal-mistakes/skins/_rte.scss
+++ b/_sass/minimal-mistakes/skins/_rte.scss
@@ -203,7 +203,7 @@ $navicon-link-color-hover: mix(#fff, $text-color, 80%) !default;
     margin-bottom: 2rem;
 
     img {
-      max-width: 20rem;
+      width: 20rem;
       max-height: 20rem;
       margin: auto;
     }


### PR DESCRIPTION
This fixes the logo size when uploaded logo is small (see GridSuite project page)
Before:
![image](https://github.com/user-attachments/assets/0efadb8b-155a-4c1c-9678-46775920538c)

After:
![image](https://github.com/user-attachments/assets/57bc71da-3b89-4fb9-a6b2-1e462af9a268)
